### PR TITLE
Add task support to admin and status UI

### DIFF
--- a/build/web/admin.html
+++ b/build/web/admin.html
@@ -16,6 +16,8 @@
     <textarea id="story"></textarea>
     <label>Optionen (eine pro Zeile):</label>
     <textarea id="options"></textarea>
+    <label>Aufgaben (eine pro Zeile):</label>
+    <textarea id="tasks"></textarea>
     <button type="submit">Story senden</button>
   </form>
 
@@ -35,7 +37,8 @@
         headers: {'Content-Type': 'application/json'},
         body: JSON.stringify({
           story: document.getElementById("story").value,
-          options: document.getElementById("options").value.split("\n")
+          options: document.getElementById("options").value.split("\n"),
+          tasks: document.getElementById("tasks").value.split("\n")
         })
       });
     });

--- a/build/web/index.html
+++ b/build/web/index.html
@@ -13,6 +13,7 @@
   <h1>🗺️ Chatdungeon Status</h1>
   <div id="story">Lade Geschichte...</div>
   <div id="options"></div>
+  <div id="tasks"></div>
   <div id="enemy" style="margin-top:20px;"></div>
   <div id="players" style="margin-top:20px;"></div>
 
@@ -22,10 +23,14 @@
       const data = await res.json();
       document.getElementById("story").innerText = data.story;
       document.getElementById("enemy").innerHTML = data.gegner ? `<strong>👾 Gegner:</strong> ${data.gegner}` : '';
-      document.getElementById("players").innerHTML = '<strong>👥 Teilnehmer:</strong><ul>' + 
+      document.getElementById("players").innerHTML = '<strong>👥 Teilnehmer:</strong><ul>' +
         data.teilnehmer.map(p => `<li>${p}</li>`).join('') + '</ul>';
-      document.getElementById("options").innerHTML = data.options.map(opt => 
+      document.getElementById("options").innerHTML = data.options.map(opt =>
         `<div class="card">${opt}</div>`).join('');
+      document.getElementById("tasks").innerHTML = data.tasks && data.tasks.length
+        ? '<strong>📝 Aufgaben:</strong><ul>' +
+          data.tasks.map(t => `<li>${t}</li>`).join('') + '</ul>'
+        : '';
     }
 
     loadStatus();

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -29,6 +29,7 @@ class StatusPage extends StatefulWidget {
 class _StatusPageState extends State<StatusPage> {
   String story = '⏳ Warte auf den Spielleiter...';
   List<String> options = [];
+  List<String> tasks = [];
   String? gegner;
   List<String> teilnehmer = [];
 
@@ -46,6 +47,7 @@ class _StatusPageState extends State<StatusPage> {
         setState(() {
           story = data['story'] ?? '';
           options = List<String>.from(data['options'] ?? []);
+          tasks = List<String>.from(data['tasks'] ?? []);
           gegner = data['enemy'];
           teilnehmer = List<String>.from(data['players'] ?? []);
         });
@@ -95,6 +97,28 @@ class _StatusPageState extends State<StatusPage> {
                   ),
                 ),
               ),
+              if (tasks.isNotEmpty) ...[
+                const SizedBox(height: 16),
+                const Text(
+                  '📝 Aufgaben',
+                  style: TextStyle(color: Colors.white, fontSize: 20),
+                ),
+                const SizedBox(height: 8),
+                ...tasks.map(
+                  (t) => Container(
+                    margin: const EdgeInsets.symmetric(vertical: 2),
+                    padding: const EdgeInsets.all(12),
+                    decoration: BoxDecoration(
+                      color: Colors.grey[850],
+                      borderRadius: BorderRadius.circular(8),
+                    ),
+                    child: Text(
+                      t,
+                      style: const TextStyle(color: Colors.white),
+                    ),
+                  ),
+                ),
+              ],
               const SizedBox(height: 20),
               if (gegner != null)
                 Column(


### PR DESCRIPTION
## Summary
- allow admins to input tasks when sending a story
- display tasks on the status page
- parse and show tasks in the Flutter app

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846eff7e0848325b541ac8c3382fb33